### PR TITLE
Add modern block structure and missing partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AjaxinWP presents a minimalist yet robust barebone framework for WordPress theme
 - **Performance Optimized**: A lightweight foundation that prioritizes speed and responsiveness.
 - **SEO and Accessibility Ready**: Meets web accessibility standards and SEO best practices out of the box.
 - **Developer-friendly Customization**: Provides a clean slate for extensive customization and feature development.
+- **Modern Block Theme Support**: Includes `theme.json` and block-based templates for seamless integration with the WordPress block editor.
 
 ## Installation
 

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -1,0 +1,7 @@
+( function( $ ) {
+    wp.customize( 'ajaxinwp_color_scheme', function( value ) {
+        value.bind( function( to ) {
+            document.documentElement.style.setProperty( '--ajaxinwp-color-scheme', to );
+        } );
+    } );
+} )( jQuery );

--- a/functions.php
+++ b/functions.php
@@ -42,6 +42,11 @@ if ( ! function_exists( 'ajaxinwp_setup' ) ) :
 
         // Add theme support for responsive embeds.
         add_theme_support( 'responsive-embeds' );
+
+        // Enable core block styles and editor styles.
+        add_theme_support( 'wp-block-styles' );
+        add_theme_support( 'editor-styles' );
+        add_editor_style( 'assets/css/theme.css' );
     }
 endif;
 add_action( 'after_setup_theme', 'ajaxinwp_setup' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -47,7 +47,7 @@ add_action( 'customize_register', 'ajaxinwp_customize_register' );
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function ajaxinwp_customize_preview_js() {
-    wp_enqueue_script( 'ajaxinwp_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20151215', true );
+    wp_enqueue_script( 'ajaxinwp_customizer', get_template_directory_uri() . '/assets/js/customizer.js', array( 'customize-preview' ), '20151215', true );
 }
 
 add_action( 'customize_preview_init', 'ajaxinwp_customize_preview_js' );

--- a/partials/partials-archive.php
+++ b/partials/partials-archive.php
@@ -1,12 +1,14 @@
 <?php
 if (have_posts()) :
     while (have_posts()) : the_post(); ?>
-        <div class="home-post">
-            <h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+        <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+            <header class="entry-header">
+                <h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+            </header>
             <div class="entry-summary">
                 <?php the_excerpt(); ?>
             </div>
-        </div>
+        </article>
     <?php endwhile;
 else :
     echo '<p>' . esc_html__( 'No posts found.', 'ajaxinwp' ) . '</p>';

--- a/partials/partials-page.php
+++ b/partials/partials-page.php
@@ -1,0 +1,18 @@
+<?php
+while (have_posts()) : the_post(); ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+    <header class="entry-header">
+        <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+    </header>
+
+    <div class="entry-content">
+        <?php the_content(); ?>
+        <?php
+        wp_link_pages(array(
+            'before' => '<div class="page-links">' . esc_html__('Pages:', 'ajaxinwp'),
+            'after'  => '</div>',
+        ));
+        ?>
+    </div>
+</article>
+<?php endwhile; ?>

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"tagName":"footer","layout":{"inherit":true}} -->
+<footer class="wp-block-group">
+    <!-- wp:site-title {"level":0} /-->
+</footer>
+<!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"header","layout":{"inherit":true}} -->
+<header class="wp-block-group">
+    <!-- wp:site-title /-->
+    <!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left"}} /-->
+</header>
+<!-- /wp:group -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+<!-- wp:template-part {"slug":"header","theme":"ajax-in-wordpress"} /-->
+
+<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date"},"layout":{"inherit":true}} -->
+    <!-- wp:post-template -->
+        <!-- wp:post-title {"isLink":true} /-->
+        <!-- wp:post-excerpt /-->
+    <!-- /wp:post-template -->
+<!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer","theme":"ajax-in-wordpress"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,0 +1,6 @@
+<!-- wp:template-part {"slug":"header","theme":"ajax-in-wordpress"} /-->
+
+<!-- wp:post-title {"level":1} /-->
+<!-- wp:post-content /-->
+
+<!-- wp:template-part {"slug":"footer","theme":"ajax-in-wordpress"} /-->

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,30 @@
+{
+    "version": 2,
+    "settings": {
+        "color": {
+            "custom": false,
+            "palette": [
+                { "slug": "primary", "color": "#1e73be", "name": "Primary" },
+                { "slug": "foreground", "color": "#333333", "name": "Foreground" }
+            ]
+        },
+        "typography": {
+            "fontFamilies": [
+                {
+                    "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+                    "slug": "system",
+                    "name": "System"
+                }
+            ],
+            "fontSizes": [
+                { "slug": "small", "size": "14px", "name": "Small" },
+                { "slug": "medium", "size": "18px", "name": "Medium" },
+                { "slug": "large", "size": "24px", "name": "Large" }
+            ]
+        },
+        "layout": {
+            "contentSize": "700px",
+            "wideSize": "1200px"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing archive and page partials
- fix home partial markup
- provide customizer.js and update enqueue path
- enable block theme features in `functions.php`
- introduce `theme.json` and block HTML templates
- document modern block theme support in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f4e7f3cd4832487503f0d9d723c9c